### PR TITLE
Making it simpler for other entities to add support for view_mode_tab

### DIFF
--- a/view_mode_tab.inc
+++ b/view_mode_tab.inc
@@ -3,22 +3,23 @@
 /**
  * Loads all the view modes for this node and then outputs them.
  */
-function _view_mode_tab_load($node) {
+function _view_mode_tab_load($entity_type, $entity) {
+  list($id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
   $output = '';
-  $settings = variable_get('view_mode_tab_settings__' . $node->type, array());
+  $settings = variable_get('view_mode_tab_settings__' . $entity_type . '__' . $bundle, array());
 
   $entity_info = entity_get_info();
 
-  if (!empty($entity_info['node']['view modes'])) {
-    $view_modes = array_keys($entity_info['node']['view modes']);
+  if (!empty($entity_info[$entity_type]['view modes'])) {
+    $view_modes = array_keys($entity_info[$entity_type]]['view modes']);
 
     $header = array();
-    $rendered_node = array();
+    $rendered_entity = array();
     foreach ($view_modes as $view_mode) {
       if (!isset($settings[$view_mode]) || $settings[$view_mode] !== 0) {
         $id = drupal_html_id($view_mode);
         $header[] = l($view_mode, 'node/' . $node->nid . '/view_modes', array('fragment' => $id));
-        $rendered_node[$view_mode] = array(
+        $rendered_entity[$view_mode] = array(
           'view_mode' => node_view($node, $view_mode),
           'header_id' => $id,
         );
@@ -26,7 +27,7 @@ function _view_mode_tab_load($node) {
     }
 
     $output .= theme('item_list', array('items' => $header));
-    $output .= theme('view_mode_tab_display', array('view_modes' => $rendered_node, 'node' => $node));
+    $output .= theme('view_mode_tab_display', array('view_modes' => $rendered_entity, $entity_type => $node));
   }
   return $output;
 }

--- a/view_mode_tab.inc
+++ b/view_mode_tab.inc
@@ -15,12 +15,13 @@ function _view_mode_tab_load($entity_type, $entity) {
 
     $header = array();
     $rendered_entity = array();
+    $uri_info = entity_uri($entity_type, $entity);
     foreach ($view_modes as $view_mode) {
       if (!isset($settings[$view_mode]) || $settings[$view_mode] !== 0) {
         $id = drupal_html_id($view_mode);
-        $header[] = l($view_mode, 'node/' . $node->nid . '/view_modes', array('fragment' => $id));
+        $header[] = l($view_mode, $uri_info['path'] . '/view_modes', array('fragment' => $id));
         $rendered_entity[$view_mode] = array(
-          'view_mode' => node_view($node, $view_mode),
+          'view_mode' => entity_view($entity_type, $entity, $view_mode),
           'header_id' => $id,
         );
       }

--- a/view_mode_tab.info
+++ b/view_mode_tab.info
@@ -1,4 +1,5 @@
 name = View Mode Tab
 description = Provides a tab which shows a node rendered into all it's view modes
 core = 7.x
+dependencies[] = entity
 files[] = view_mode_tab.module

--- a/view_mode_tab.module
+++ b/view_mode_tab.module
@@ -21,7 +21,7 @@ function view_mode_tab_menu() {
   $items['node/%node/view_modes'] = array(
     'title' => 'View Modes',
     'page callback' => '_view_mode_tab_load',
-    'page arguments' => array(1),
+    'page arguments' => array('node', 1),
     'access callback' => 'view_mode_tab_page_access',
     'access arguments' => array(1),
     'type' => MENU_LOCAL_TASK,


### PR DESCRIPTION
Still requires some cleanup, there's stuff in that function that is still extremely node specific.

But the idea is that I can add support on other modules by doing a simple

``` php
   $items['my-entity/%my-entity/view_modes'] = array(
     'title' => 'View Modes',
     'page callback' => '_view_mode_tab_load',
+    'page arguments' => array('my-entity', 1),
     'access callback' => 'view_mode_tab_page_access',
     'access arguments' => array('my-entity', 1),
     'type' => MENU_LOCAL_TASK,
     'file' => 'view_mode_tab.inc',
     'weight' => 100,
   );
```
